### PR TITLE
Update Frontend Engineer opening copy

### DIFF
--- a/src/components/JobOpenings.js
+++ b/src/components/JobOpenings.js
@@ -94,7 +94,7 @@ const JobOpenings = () => (
         title="Frontend Engineer"
         open="frontend-engineer"
         idprop="systems-engineer"
-        description="We're looking for a Frontend Engineer with a love for beautiful, well-crafted interfaces. You'll work with our rockstar frontend team building Aragon Labs, Aragon client, and aragonOS.">
+        description="We're looking for a Frontend Engineer with a love for beautiful, well-crafted interfaces. You'll work with our frontend team building Aragon Labs, Aragon client, and aragonUI.">
         <h5>Responsibilities</h5>
         <ul>
           <li>


### PR DESCRIPTION
- "Rockstar engineer" is a played-out trope that hurts the credibility of the ad
- Changed aragonOS -> aragonUI 

We should probably also remove Aragon Labs from this ad since that's not really an active program anymore.